### PR TITLE
feat: we don't need jsx in scope anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
     "react/prop-types": 0,
     "react/jsx-handler-names": 0,
     "react/jsx-curly-newline": 0,
+    "react/react-in-jsx-scope": 0,
     "no-use-before-define": ["error", { "functions": true, "classes": true, "variables": true }],
     "@typescript-eslint/no-unused-vars": "error",
   },


### PR DESCRIPTION
With react 17+ or nextjs we don't need to have React in scope. There is an [automatic mode](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)